### PR TITLE
[FEAT] 로그인 후 토큰 발급 시 1분 뒤 만료되는 토큰 발행할 수 있도록 API param 추가

### DIFF
--- a/src/errors/exceptions.py
+++ b/src/errors/exceptions.py
@@ -29,5 +29,11 @@ class EntityNotFoundException(CustomException):
                                           f"{f": lookup fields: {self.lookup_fields}" if self.lookup_fields else ""}")
 
 
+class InvalidJwtException(CustomException):
+    def __init__(self, msg: str | None = None, code: int = 40100):
+        super().__init__(msg)
+        self.code = code
+
+
 class MissingEnvVarException(CustomException):
     pass

--- a/src/main.py
+++ b/src/main.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
-from fastapi.exceptions import ValidationException, RequestValidationError, ResponseValidationError
+from fastapi.exceptions import ValidationException, RequestValidationError, ResponseValidationError, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.encoders import ENCODERS_BY_TYPE
 from starlette import status
 from starlette.middleware.cors import CORSMiddleware
 
 from database import Base, engine
-from errors.exceptions import EntityNotFoundException, UnauthorizedException
+from errors.exceptions import EntityNotFoundException, UnauthorizedException, InvalidJwtException
 from models.response import ErrorResponse
 from views import routers
 
@@ -64,7 +64,7 @@ async def unauthorized_exception_handler(_: Request, exc: UnauthorizedException)
     res_code = status.HTTP_401_UNAUTHORIZED
     return JSONResponse(
         status_code=res_code,
-        content={"status": res_code, "data": None, "message": exc.msg}
+        content={"status": res_code, "message": exc.msg}
     )
 
 
@@ -73,7 +73,16 @@ async def entity_not_found_exception_handler(_: Request, exc: EntityNotFoundExce
     res_code = status.HTTP_404_NOT_FOUND
     return JSONResponse(
         status_code=res_code,
-        content={"status": res_code, "data": None, "message": str(exc)}
+        content={"status": res_code, "message": str(exc)}
+    )
+
+
+@app.exception_handler(InvalidJwtException)
+async def invalid_jwt_exception_handler(_: Request, exc: InvalidJwtException):
+    res_code = status.HTTP_401_UNAUTHORIZED
+    return JSONResponse(
+        status_code=res_code,
+        content={"status": exc.code, "message": str(exc)}
     )
 
 

--- a/src/services/login.py
+++ b/src/services/login.py
@@ -1,3 +1,4 @@
+import datetime
 from http import HTTPStatus
 from typing import Annotated
 
@@ -14,9 +15,10 @@ from services.token import create_access_token, create_refresh_token
 from transaction import Transaction
 
 
-def get_token(user_id: int) -> BaseTokenDto:
-    access_token = create_access_token(user_id)
-    refresh_token = create_refresh_token(user_id)
+def get_token(user_id: int, short: bool = False) -> BaseTokenDto:
+    timedelta = datetime.timedelta(minutes=1) if short else None
+    access_token = create_access_token(user_id, timedelta)
+    refresh_token = create_refresh_token(user_id, timedelta)
     return BaseTokenDto(**{
         "access_token": access_token,
         "refresh_token": refresh_token
@@ -29,10 +31,10 @@ class LoginService:
         self.user_repository = user_repo
         self.transaction = transaction
 
-    def handle_login(self, access_token: str, login_method: str) -> BaseTokenDto:
+    def handle_login(self, access_token: str, login_method: str, short: bool = False) -> BaseTokenDto:
         if login_method == "KAKAO":
             user_id = self.request_kakao_user_info(access_token)
-            return get_token(user_id)
+            return get_token(user_id, short)
         else:
             raise Exception("Invalid login method")
 

--- a/src/services/token.py
+++ b/src/services/token.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException, Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwt
 
-from errors.exceptions import MissingEnvVarException
+from errors.exceptions import MissingEnvVarException, InvalidJwtException
 
 load_dotenv('src/../.env')
 
@@ -21,24 +21,27 @@ if not SECRET_KEY or not ALGORITHM:
 
 def create_access_token(user_id: int, expires_delta: timedelta | None = None) -> str:
     to_encode: Dict[str, Any] = {"user_id": user_id}
+    now = datetime.now(tz=timezone.utc)
     if expires_delta:
-        expire = datetime.now() + expires_delta
+        expire = now + expires_delta
     else:
-        expire = datetime.now() + timedelta(days=1)
-    to_encode.update({"exp": expire})
+        expire = now + timedelta(days=1)
+    to_encode.update({"exp": expire.replace(tzinfo=timezone.utc)})
     to_encode.update({"sub": "access_token"})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
 
 def create_refresh_token(user_id: int, expires_delta: timedelta | None = None) -> str:
+    now = datetime.now(tz=timezone.utc)
+
     if expires_delta:
-        expire = datetime.now() + expires_delta
+        expire = now + expires_delta
     else:
-        expire = datetime.now() + timedelta(days=30)
+        expire = now + timedelta(days=30)
     encoded_jwt = jwt.encode({
         "sub": "refresh_token",
-        "exp": expire,
+        "exp": expire.replace(tzinfo=timezone.utc),
         "user_id": user_id
     }, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
@@ -48,12 +51,12 @@ def decode_access_token(token):
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=ALGORITHM)
         if payload['sub'] != "access_token":
-            raise HTTPException(status_code=401, detail='Invalid token')
+            raise InvalidJwtException(code=40101, msg='Invalid token')
         return payload['user_id']
     except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=401, detail='Signature has expired')
+        raise InvalidJwtException(code=40102, msg='Signature has expired')
     except jwt.JWTClaimsError as _:
-        raise HTTPException(status_code=401, detail='Invalid token')
+        raise InvalidJwtException(code=40103, msg='Invalid token')
 
 
 def decode_refresh_token(token) -> int:

--- a/src/views/login.py
+++ b/src/views/login.py
@@ -21,5 +21,6 @@ class LoginView:
                             " (유효기간: access token - 1일, refresh token - 30일)<br/>"
                             "*카카오 닉네임이 자동으로 서비스 닉네임으로 저장됩니다."
                 )
-    def kakao_login(self, access_token: Annotated[str, Query(alias="accessToken")]) -> BaseTokenDto:
-        return self.login_service.handle_login(access_token, "KAKAO")
+    def kakao_login(self, access_token: Annotated[str, Query(alias="accessToken")],
+                    short: Annotated[bool, Query()] = False) -> BaseTokenDto:
+        return self.login_service.handle_login(access_token, "KAKAO", short)


### PR DESCRIPTION
## PR Checklist
PR 전 다음 요구사항을 충족했는지 점검해주세요. 
- [X] 추가된 변경사항에 대해 테스트했나요? (버그수정 / 추가 기능)
- [ ] PR에 대한 사항이 충분히 문서화되었나요? (버그수정 / 추가 기능)


## PR Type
해당 PR은 어떤 변경점에 관한 것인가요?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [X] 새로운 기능 추가
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리펙토링 (기능변경 X, API 변경 X)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] 문서화된 내용 수정
- [ ] 기타 변경사항


## 현재 어떤 문제/개선점이 있나요?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue 번호: N/A


## 무엇이 추가/수정되나요?
만료주기가 짧은 token을 생성할 수 있도록 api 호출 시 받는 optional parameter `short`(boolean) 가  추가되었습니다.
-> short: true인 경우 access token 및 refresh token 모두 1분뒤에 만료되도록 발급됩니다.
 
API: [GET] `/login/kakao`

## 기타 참고내용
- 없음
