### PR TITLE
[FIX] 셀 삭제 시 하위 셀 정보 초기화 로직 추가

### DIFF
--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -21,9 +21,11 @@ class BaseRepository(Generic[T]):
     def find_by_id(self, entity_id: int) -> T | None:
         return self._db.query(self.__model).filter(self.__model.id == entity_id).first()
 
-    def create_or_update(self, entity: T) -> T:
+    def create_or_update(self, entity: T):
         self._db.add(entity)
-        return entity
+
+    def create_or_update_all(self, entities: list[T]):
+        self._db.bulk_save_objects(entities)
 
     def delete(self, entity: T) -> None:
         self._db.delete(entity)

--- a/src/services/cell.py
+++ b/src/services/cell.py
@@ -75,7 +75,15 @@ class CellService:
             cell.goal = None
             cell.todos = []
             cell.is_completed = False
-            self.cell_repo.create_or_update(cell)
+            if cell.step == 2:
+                for child in cell.children:
+                    child.color = None
+                    child.goal = None
+                    child.todos = []
+                    child.is_completed = False
+
+        self.cell_repo.create_or_update(cell)
+
         return GetCellWithTodosDto.from_orm(cell)
 
     def update_cell(self, dto: UpdateCellDto, user_id: int, cell_id: int) -> GetCellWithTodosDto:

--- a/src/services/login.py
+++ b/src/services/login.py
@@ -55,8 +55,12 @@ class LoginService:
         social_provider = SocialProvider.KAKAO
         user = self.user_repository.find_by_social_provider_and_social_id(social_provider=social_provider,
                                                                           social_id=str(social_id))
-        if user is None:
+        try:
             nickname = res_body['kakao_account']['profile']['nickname']
+        except KeyError:
+            nickname = None
+
+        if user is None:
             user = User(social_provider=social_provider, social_id=social_id, nickname=nickname)
             with self.transaction:
                 self.user_repository.create_or_update(user)

--- a/src/views/cell.py
+++ b/src/views/cell.py
@@ -50,6 +50,6 @@ class CellView(AuthView):
         return self.cell_service.get_children_cells_by_id(self.user_id, cell_id)
 
     @router.delete("/cell/{cell_id}", summary="cell 의 내용을 전부 삭제합니다(초기화).", tags=["cell"],
-                   description="셀의 내용을 전부 삭제합니다. 하위 셀의 관계와 정보는 그대로 유지됩니다.")
+                   description="셀의 내용을 전부 삭제합니다. 해당 cell이 depth 2인 경우 하위 셀의 정보를 모두 초기화합니다.")
     def delete_cell(self, cell_id: int) -> GetCellWithTodosDto:
         return self.cell_service.delete_cell(self.user_id, cell_id)


### PR DESCRIPTION
## PR Checklist
PR 전 다음 요구사항을 충족했는지 점검해주세요. 
- [X] 추가된 변경사항에 대해 테스트했나요? (버그수정 / 추가 기능)
- [X] PR에 대한 사항이 충분히 문서화되었나요? (버그수정 / 추가 기능)


## PR Type
해당 PR은 어떤 변경점에 관한 것인가요?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정
- [X] 새로운 기능 추가
- [ ] 코드 스타일 업데이트 (formatting, local variables)
- [ ] 리펙토링 (기능변경 X, API 변경 X)
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항
- [ ] 문서화된 내용 수정
- [ ] 기타 변경사항


## 현재 어떤 문제/개선점이 있나요?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue 번호: N/A


## 무엇이 추가/수정되나요?
셀 삭제 시 depth2 인 셀의 경우 하위 셀정보까지 모두 초기화하도록 로직 수정

## 기타 참고내용
- 없음
